### PR TITLE
adding ability to suppress the output window

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ Open VSCode Editor and Press `ctrl+P`, type `ext install live-sass`.
         ]
      ``` 
      <hr>
+* **`liveSassCompile.settings.showOutputWindow` :** Set this to `false` if you do not want the output window to show.    
+    * *NOTE: You can use the command palette to open the Live Sass output window.*
+    * *Default value is `true`*
+
+     <hr>
 
 ## Extension Dependency 
 This extension has dependency on _[Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)_ extension for live browser reload.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
                 "command": "liveSass.command.oneTimeCompileSass",
                 "title": "Compile Sass - Without Watch Mode",
                 "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.openOutputWindow",
+                "title": "Open Live Sass Output Window",
+                "category": "Live Sass"
             }
         ],
         "configuration": {
@@ -136,6 +141,11 @@
                     ],
                     "default": null,
                     "description": "Automatically add vendor prefixes to unsupported CSS properties (e. g. transform -> -ms-transform). Specify what browsers to target with an array of strings (uses [Browserslist](https://github.com/ai/browserslist)). Pass `null` to turn off. \nDefault is `null`"
+                },
+                "liveSassCompile.settings.showOutputWindow": {
+                    "type" : "boolean",
+                    "default": true,
+                    "description": "Set this to `false` if you do not want the output window to show.\nNote: You can use the command palette to open the Live Sass output window.\nDefault is `true`"
                 }
             }
         }

--- a/src/StatubarUi.ts
+++ b/src/StatubarUi.ts
@@ -23,12 +23,14 @@ export class StatusBarUi {
 
     static watching() {
         StatusBarUi.statusBarItem.text = `$(telescope) Watching...`;
+        StatusBarUi.statusBarItem.color = 'inherit';
         StatusBarUi.statusBarItem.command = 'liveSass.command.donotWatchMySass';
         StatusBarUi.statusBarItem.tooltip = 'Stop live compilation of SASS or SCSS to CSS';
     }
 
     static notWatching() {
         StatusBarUi.statusBarItem.text = `$(eye) Watch Sass`;
+        StatusBarUi.statusBarItem.color = 'inherit';
         StatusBarUi.statusBarItem.command = 'liveSass.command.watchMySass';
         StatusBarUi.statusBarItem.tooltip = 'live compilation of SASS or SCSS to CSS';
     }
@@ -37,6 +39,28 @@ export class StatusBarUi {
         StatusBarUi.statusBarItem.text = `$(pulse) ${workingMsg}`;
         StatusBarUi.statusBarItem.tooltip = 'In case if it takes long time, Show output window and report.';
         StatusBarUi.statusBarItem.command = null;
+    }
+
+    // Quick status bar messages after compile success or error
+    static compilationSuccess() {
+        StatusBarUi.statusBarItem.text = `$(check) Success`;
+        StatusBarUi.statusBarItem.color = '#33ff00';
+        StatusBarUi.statusBarItem.command = null;
+
+        setTimeout( function() {
+            StatusBarUi.statusBarItem.color = 'inherit';
+            StatusBarUi.watching();
+        }, 4500);
+    }
+    static compilationError() {
+        StatusBarUi.statusBarItem.text = `$(x) Error`;
+        StatusBarUi.statusBarItem.color = '#ff0033';
+        StatusBarUi.statusBarItem.command = null;
+
+        setTimeout( function() {
+            StatusBarUi.statusBarItem.color = 'inherit';
+            StatusBarUi.watching();
+        }, 4500);
     }
 
     static dispose() {

--- a/src/StatubarUi.ts
+++ b/src/StatubarUi.ts
@@ -42,25 +42,35 @@ export class StatusBarUi {
     }
 
     // Quick status bar messages after compile success or error
-    static compilationSuccess() {
+    static compilationSuccess(isWatching) {
         StatusBarUi.statusBarItem.text = `$(check) Success`;
         StatusBarUi.statusBarItem.color = '#33ff00';
         StatusBarUi.statusBarItem.command = null;
 
-        setTimeout( function() {
-            StatusBarUi.statusBarItem.color = 'inherit';
-            StatusBarUi.watching();
-        }, 4500);
+        if(isWatching) {
+            setTimeout( function() {
+                StatusBarUi.statusBarItem.color = 'inherit';
+                StatusBarUi.watching();
+            }, 4500);
+        }
+        else {
+            StatusBarUi.notWatching();
+        }   
     }
-    static compilationError() {
+    static compilationError(isWatching) {
         StatusBarUi.statusBarItem.text = `$(x) Error`;
         StatusBarUi.statusBarItem.color = '#ff0033';
         StatusBarUi.statusBarItem.command = null;
 
-        setTimeout( function() {
-            StatusBarUi.statusBarItem.color = 'inherit';
-            StatusBarUi.watching();
-        }, 4500);
+        if(isWatching) {
+            setTimeout( function() {
+                StatusBarUi.statusBarItem.color = 'inherit';
+                StatusBarUi.watching();
+            }, 4500);
+        }
+        else {
+            StatusBarUi.notWatching();
+        }
     }
 
     static dispose() {

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -35,12 +35,19 @@ export class AppModel {
             return;
         }
         StatusBarUi.working();
-        this.GenerateAllCssAndMap().then(() => {
+
+        let showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
+
+        this.GenerateAllCssAndMap(showOutputWindow).then(() => {
             if (!WatchingMode) {
                 this.isWatching = true; // tricky to toggle status
             }
             this.toggleStatusUI();
         });
+    }
+    
+    openOutputWindow() {
+        OutputWindow.Show(null, null, true);
     }
 
     async compileOnSave() {
@@ -85,13 +92,15 @@ export class AppModel {
 
     private toggleStatusUI() {
         this.isWatching = !this.isWatching;
+        let showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
+        
         if (!this.isWatching) {
             StatusBarUi.notWatching();
-            OutputWindow.Show('Not Watching...', null, true);
+            OutputWindow.Show('Not Watching...', null, showOutputWindow);
         }
         else {
             StatusBarUi.watching();
-            OutputWindow.Show('Watching...', null, true);
+            OutputWindow.Show('Watching...', null, showOutputWindow);
         }
 
     }
@@ -154,12 +163,19 @@ export class AppModel {
     private GenerateCssAndMap(SassPath: string, targetCssUri: string, mapFileUri: string, options) {
         let generateMap = Helper.getConfigSettings<boolean>('generateMap');
         let autoprefixerTarget = Helper.getConfigSettings<Array<string>>('autoprefix');
+        let showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
 
         return new Promise(resolve => {
             SassHelper.instance.compileOne(SassPath, options)
                 .then(async result => {
                     if (result.status !== 0) {
-                        OutputWindow.Show('Compilation Error', [result.formatted], true);
+                        OutputWindow.Show('Compilation Error', [result.formatted], showOutputWindow);
+                        StatusBarUi.compilationError();
+
+                        if(!showOutputWindow) {
+                            vscode.window.setStatusBarMessage(result.formatted.split('\n')[0], 4500);
+                        }
+
                         resolve(true);
                     }
                     else {
@@ -204,10 +220,11 @@ export class AppModel {
 
     /**
      * To compile all Sass/scss files
-     * @param popUpOutputWindow To control output window. default value is true.
+     * @param popUpOutputWindow To control output window. 
      */
-    private GenerateAllCssAndMap(popUpOutputWindow = true) {
+    private GenerateAllCssAndMap(popUpOutputWindow) {
         let formats = Helper.getConfigSettings<IFormat[]>('formats');
+
         return new Promise((resolve) => {
             this.findAllSaasFilesAsync((sassPaths: string[]) => {
                 OutputWindow.Show('Compiling Sass/Scss Files: ', sassPaths, popUpOutputWindow);
@@ -314,6 +331,7 @@ export class AppModel {
      * @param target What browsers to be targeted, as supported by [Browserslist](https://github.com/ai/browserslist)
      */
     private async autoprefix(css: string, browsers: Array<string>): Promise<string> {
+        let showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
         const prefixer = postcss([
             autoprefixer({
                 browsers
@@ -324,7 +342,7 @@ export class AppModel {
             .process(css)
             .then(res => {
                 res.warnings().forEach(warn => {
-                    OutputWindow.Show('Autoprefix Error', [warn.text], true);
+                    OutputWindow.Show('Autoprefix Error', [warn.text], showOutputWindow);
                 });
                 return res.css;
             });

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -170,7 +170,7 @@ export class AppModel {
                 .then(async result => {
                     if (result.status !== 0) {
                         OutputWindow.Show('Compilation Error', [result.formatted], showOutputWindow);
-                        StatusBarUi.compilationError();
+                        StatusBarUi.compilationError(this.isWatching);
 
                         if(!showOutputWindow) {
                             vscode.window.setStatusBarMessage(result.formatted.split('\n')[0], 4500);
@@ -197,6 +197,7 @@ export class AppModel {
 
                         Promise.all(promises).then(fileResolvers => {
                             OutputWindow.Show('Generated :', null, false, false);
+                            StatusBarUi.compilationSuccess(this.isWatching);
                             fileResolvers.forEach(fileResolver => {
                                 if (fileResolver.Exception) {
                                     OutputWindow.Show('Error:', [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,10 @@ export function activate(context: vscode.ExtensionContext) {
             appModel.compileAllFiles(false);
         });
 
+    let disposableOpenOutputWindow =
+        vscode.commands.registerCommand('liveSass.command.openOutputWindow', () => {
+            appModel.openOutputWindow();
+        })
     let disposableOnDivSave =
         vscode.workspace.onDidSaveTextDocument(() => {
             appModel.compileOnSave();
@@ -35,6 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
         disposableStopWaching,
         disposableOnDivSave,
         disposableOneTimeCompileSass,
+        disposableOpenOutputWindow,
         appModel);
 }
 


### PR DESCRIPTION
Adds a setting that allows the user to suppress all of the output window popups. It is set to true by default, which allows the extension to run as originally intended.  The status bar item also changes to a green 'Success' if there were no errors during compilation, and a red 'error' if there were.